### PR TITLE
Make sure to not use influxdb 0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu
 MAINTAINER Matt Baldwin (baldwin@stackpointcloud.com)
 
+ENV DEBIAN_FRONTEND noninteractive
 RUN \
   apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \
@@ -27,17 +28,18 @@ RUN \
 WORKDIR /opt
 RUN \
   curl -s -o grafana.tar.gz "https://grafanarel.s3.amazonaws.com/builds/grafana-latest.linux-x64.tar.gz" && \
-  curl -s -o influxdb_latest_amd64.deb http://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb && \
+  curl -s -o influxdb_amd64.deb "https://s3.amazonaws.com/influxdb/influxdb_0.8.8_amd64.deb" && \
   mkdir grafana && \
-  tar -xzf grafana.tar.gz --directory grafana --strip-components=1 && \
-  dpkg -i influxdb_latest_amd64.deb && \
+  tar -xzf grafana.tar.gz --directory grafana --strip-components=1 && rm grafana.tar.gz && \
+  dpkg -i influxdb_amd64.deb && rm influxdb_amd64.deb && \
   echo "influxdb soft nofile unlimited" >> /etc/security/limits.conf && \
-  echo "influxdb hard nofile unlimited" >> /etc/security/limits.conf
+  echo "influxdb hard nofile unlimited" >> /etc/security/limits.conf && \
+  apt-get clean
 
-ADD config.js /opt/grafana/config.js
-ADD nginx.conf /etc/nginx/nginx.conf
-ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-ADD config.toml /opt/influxdb/current/config.toml
+COPY config.js /opt/grafana/config.js
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY supervisord.conf /etc/supervisor/conf.d/influx-nginx.conf
+COPY config.toml /opt/influxdb/current/config.toml
 
 VOLUME ["/opt/influxdb/shared/data"]
 


### PR DESCRIPTION
Influxdb 0.9 has a new directory structure and config file, this version of the Dockerfile only works with 0.8.8. Also make sure to clean up the downloaded archives. Use best-practice COPY statement and make sure supervisor.d file has a telling name. Download from https.